### PR TITLE
Added '/api' to template 'formDescriptionBrapiUrl'

### DIFF
--- a/src/plugins/i18n/de_DE.json
+++ b/src/plugins/i18n/de_DE.json
@@ -122,7 +122,7 @@
   "formLabelColCount": "Keine Spalten | Eine Spalte | {count} Spalten",
   "formLabelRowCount": "Keine Zeilen | Eine Zeile | {count} Zeilen",
   "formLabelImportExportData": "Daten",
-  "formDescriptionBrapiUrl": "Die URL des BrAPI-Endpunktes. Normalerweise in der Form <code>{URL}/brapi/v2/</code>",
+  "formDescriptionBrapiUrl": "Die URL des BrAPI-Endpunktes. Normalerweise in der Form <code>{URL}/api/brapi/v2/</code>",
   "formDescriptionBrapiToken": "Ein Token kann benötigt werden für Schreiboperationen oder Zugriffsbeschränkungen",
   "formDescriptionDataEntryMultiPrevValue": "Vorheriger Wert gesetzt am: {date}: {prevValue}.",
   "formDescriptionImportExportData": "Importierte Daten müssen korrekt formattiert sein. Bitte Vorsicht walten lassen beim Importieren von Daten.",

--- a/src/plugins/i18n/en_GB.json
+++ b/src/plugins/i18n/en_GB.json
@@ -124,7 +124,7 @@
   "formLabelRowCount": "No rows | One row | {count} rows",
   "formLabelImportExportData": "Data",
   "formDescriptionAddGermplasm": "Enter the germplasm name/identifier.",
-  "formDescriptionBrapiUrl": "The URL of the BrAPI endpoint. Usually of the form <code>{URL}/brapi/v2/</code>",
+  "formDescriptionBrapiUrl": "The URL of the BrAPI endpoint. Usually of the form <code>{URL}/api/brapi/v2/</code>",
   "formDescriptionBrapiToken": "A token may be required for write operations or access limitations",
   "formDescriptionDataEntryMultiPrevValue": "Previous value recorded on {date}: {prevValue}.",
   "formDescriptionImportExportData": "Importing data requires it to be properly formatted. Be careful what you try to import.",


### PR DESCRIPTION
Sebastian, I just changed the template message to include the /api in between {url} and /brapi/v2 so that it's clearer. 